### PR TITLE
Fixed Optional Settings Override Mechanism

### DIFF
--- a/app/coffee/directives/imageSpinner.coffee
+++ b/app/coffee/directives/imageSpinner.coffee
@@ -27,7 +27,7 @@ angular.module('imageSpinner')
         class SpinnerBuilder
             constructor: (@el, @settings) ->
                 settings ?= {}
-                settings = angular.extend(settings, DefaultSettings)
+                settings = angular.extend(DefaultSettings, settings)
                 @spinner = new Spinner(settings)
 
                 @container = @el.parent()


### PR DESCRIPTION
Previously, adding an `image-spinner-settings` attribute will not result in changing the settings of `spin.js` plugin because of a miss-order in `angular.extend` method parameters
